### PR TITLE
Add Iff function

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,18 @@ ternary.If(true, "foo", "bar") // "foo"
 ternary.If(false, "foo", "bar") // "bar"
 
 // Use it for pluralization
-ternary.If(len(slice) > 2, "objects", "object") // "objects"
+ternary.If(len(slice) != 1, "objects", "object") // "objects"
 
 ternary.If(true, 5.4, 3.2) // 5.4
 
+// Do not use it like this, because both funcs will be evaluated regardless of condition!
+ternary.If(true, trueFunc(), falseFunc())
+
+// Instead, use the Iff function...
+ternary.Iff(true, trueFunc, falseFunc)
+
+// or with closures if the funcs require arguments
+ternary.Iff(true, func() string { return truefunc(...)}, , func() string { return falsefunc(...)})
 ```
 
 ## FAQ

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ ternary.If(true, trueFunc(), falseFunc())
 ternary.Iff(true, trueFunc, falseFunc)
 
 // or with closures if the funcs require arguments
-ternary.Iff(true, func() string { return truefunc(...)}, , func() string { return falsefunc(...)})
+ternary.Iff(true, func() string { return trueFunc(...)}, , func() string { return falseFunc(...)})
 ```
 
 ## FAQ

--- a/ternary.go
+++ b/ternary.go
@@ -34,3 +34,21 @@ func IfFunc[T any, R any](condition bool, a, b T, f func(T) R) R {
 	}
 	return f(b)
 }
+
+// Iff executes a function a or b based on the condition.
+//
+// Usage:
+//
+//	ternary.Iff(condition bool, funcIfTrue, funcIfFalse)
+//
+// Example:
+//
+//	ternary.If(true, func() string { return "foo"}, func() string { return "bar"})
+//  // returns "foo"
+
+func Iff[T any](condition bool, a, b func() T) T {
+	if condition {
+		return a()
+	}
+	return b()
+}

--- a/ternary_test.go
+++ b/ternary_test.go
@@ -387,3 +387,302 @@ func TestIfFunc(t *testing.T) {
 		})
 	}
 }
+
+func TestIff(t *testing.T) {
+
+	var trueCalled, falseCalled bool
+
+	type args struct {
+		condition bool
+		a         func() T
+		b         func() T
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want T
+	}{
+		{
+			name: "String True",
+			args: args{
+				condition: true,
+				a: func() T {
+					trueCalled = true
+					return "foo"
+				},
+				b: func() T {
+					falseCalled = true
+					return "bar"
+				},
+			},
+			want: "foo",
+		},
+
+		{
+			name: "String False",
+			args: args{
+				condition: false,
+				a: func() T {
+					trueCalled = true
+					return "foo"
+				},
+				b: func() T {
+					falseCalled = true
+					return "bar"
+				},
+			},
+			want: "bar",
+		},
+
+		{
+			name: "Int True",
+			args: args{
+				condition: true,
+				a: func() T {
+					trueCalled = true
+					return 1
+				},
+				b: func() T {
+					falseCalled = true
+					return 2
+				},
+			},
+			want: 1,
+		},
+
+		{
+			name: "Int False",
+			args: args{
+				condition: false,
+				a: func() T {
+					trueCalled = true
+					return 1
+				},
+				b: func() T {
+					falseCalled = true
+					return 2
+				},
+			},
+			want: 2,
+		},
+
+		{
+			name: "Float True",
+			args: args{
+				condition: true,
+				a: func() T {
+					trueCalled = true
+					return 1.1
+				},
+				b: func() T {
+					falseCalled = true
+					return 2.2
+				},
+			},
+			want: 1.1,
+		},
+
+		{
+			name: "Float False",
+			args: args{
+				condition: false,
+				a: func() T {
+					trueCalled = true
+					return 1.1
+				},
+				b: func() T {
+					falseCalled = true
+					return 2.2
+				},
+			},
+			want: 2.2,
+		},
+
+		{
+			name: "Bool True",
+			args: args{
+				condition: true,
+				a: func() T {
+					trueCalled = true
+					return true
+				},
+				b: func() T {
+					falseCalled = true
+					return false
+				},
+			},
+			want: true,
+		},
+
+		{
+			name: "Bool False",
+			args: args{
+				condition: false,
+				a: func() T {
+					trueCalled = true
+					return true
+				},
+				b: func() T {
+					falseCalled = true
+					return false
+				},
+			},
+			want: false,
+		},
+
+		{
+			name: "Struct True",
+			args: args{
+				condition: true,
+				a: func() T {
+					trueCalled = true
+					return struct{ foo string }{foo: "foo"}
+				},
+				b: func() T {
+					falseCalled = true
+					return struct{ foo string }{foo: "bar"}
+				},
+			},
+			want: struct{ foo string }{foo: "foo"},
+		},
+
+		{
+			name: "Struct False",
+			args: args{
+				condition: false,
+				a: func() T {
+					trueCalled = true
+					return struct{ foo string }{foo: "foo"}
+				},
+				b: func() T {
+					falseCalled = true
+					return struct{ foo string }{foo: "bar"}
+				},
+			},
+			want: struct{ foo string }{foo: "bar"},
+		},
+
+		{
+			name: "Slice True",
+			args: args{
+				condition: true,
+				a: func() T {
+					trueCalled = true
+					return []string{"foo"}
+				},
+				b: func() T {
+					falseCalled = true
+					return []string{"bar"}
+				},
+			},
+			want: []string{"foo"},
+		},
+
+		{
+			name: "Slice False",
+			args: args{
+				condition: false,
+				a: func() T {
+					trueCalled = true
+					return []string{"foo"}
+				},
+				b: func() T {
+					falseCalled = true
+					return []string{"bar"}
+				},
+			},
+			want: []string{"bar"},
+		},
+
+		{
+			name: "Map True",
+			args: args{
+				condition: true,
+				a: func() T {
+					trueCalled = true
+					return map[string]string{"foo": "foo"}
+				},
+				b: func() T {
+					falseCalled = true
+					return map[string]string{"foo": "bar"}
+				},
+			},
+			want: map[string]string{"foo": "foo"},
+		},
+
+		{
+			name: "Map False",
+			args: args{
+				condition: false,
+				a: func() T {
+					trueCalled = true
+					return map[string]string{"foo": "foo"}
+				},
+				b: func() T {
+					falseCalled = true
+					return map[string]string{"foo": "bar"}
+				},
+			},
+			want: map[string]string{"foo": "bar"},
+		},
+
+		{
+			name: "Interface True",
+			args: args{
+				condition: true,
+				a: func() T {
+					trueCalled = true
+					return interface{}("foo")
+				},
+				b: func() T {
+					falseCalled = true
+					return interface{}("bar")
+				},
+			},
+			want: interface{}("foo"),
+		},
+
+		{
+			name: "Interface False",
+			args: args{
+				condition: false,
+				a: func() T {
+					trueCalled = true
+					return interface{}("foo")
+				},
+				b: func() T {
+					falseCalled = true
+					return interface{}("bar")
+				},
+			},
+			want: interface{}("bar"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			trueCalled, falseCalled = false, false
+
+			if got := Iff(tt.args.condition, tt.args.a, tt.args.b); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Ternary() = %v, want %v", got, tt.want)
+			}
+			if tt.args.condition {
+				if !trueCalled {
+					t.Error("Expected true func (a) to be called")
+				}
+				if falseCalled {
+					t.Error("Expected false func (b) not to be called")
+				}
+			} else {
+				if trueCalled {
+					t.Error("Expected true func (a) not to be called")
+				}
+				if !falseCalled {
+					t.Error("Expected false func (b) to be called")
+				}
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
Added a method to manage the case where the true and false values are function calls.

If you pass functions rather than concrete values to `If`, then both functions are evaluated regardless of `condition` which may have undesired side effects.

The new method ensures only one of the two function arguments is evaluated.